### PR TITLE
update tailwindcss-variables version

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -24,7 +24,7 @@
     "use-debounce": "^7.0.1"
   },
   "devDependencies": {
-    "@mertasan/tailwindcss-variables": "^1.4.1",
+    "@mertasan/tailwindcss-variables": "^2.2.2",
     "@radix-ui/colors": "^0.1.8",
     "@tailwindcss/forms": "^0.5.0",
     "@tailwindcss/typography": "^0.5.2",


### PR DESCRIPTION
Npm was downloading `1.4.1` as the last version because I had released `1.4.1` after version `2.2.1`.

I fixed this ordering by releasing a new version (`v2.2.2`). The version compatible with Tailwindcss `3.x` is `2.x`

Sorry for this confusion.